### PR TITLE
enforce fragment filename pattern

### DIFF
--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -170,7 +170,15 @@ def find_fragments(
                 # Use and increment the orphan news fragment counter.
                 counter = orphan_fragment_counter[category]
                 orphan_fragment_counter[category] += 1
-
+            if config.fragment_filename_stem_pattern and (
+                not re.fullmatch(
+                    config.fragment_filename_stem_pattern, stem := Path(basename).stem
+                )
+            ):
+                raise ClickException(
+                    f"File name '{stem}' does not match the "
+                    f"given pattern, '{config.fragment_filename_stem_pattern}'"
+                )
             full_filename = os.path.join(section_dir, basename)
             fragment_files.append((full_filename, category))
             data = Path(full_filename).read_text(encoding="utf-8", errors="replace")

--- a/src/towncrier/_settings/load.py
+++ b/src/towncrier/_settings/load.py
@@ -55,6 +55,7 @@ class Config:
     create_eof_newline: bool = True
     create_add_extension: bool = True
     ignore: list[str] | None = None
+    fragment_filename_stem_pattern: str | None = None
 
 
 class ConfigError(ClickException):

--- a/src/towncrier/check.py
+++ b/src/towncrier/check.py
@@ -57,6 +57,12 @@ def _get_default_compare_branch(branches: Container[str]) -> str | None:
     metavar="FILE_PATH",
     help=config_option_help,
 )
+@click.option(
+    "--fragment-filename-pattern",
+    default=None,
+    metavar="FRAGMENT_FILE_PATTERN",
+    help=r"A regex pattern to require fragment files to match, e.g. [A-Z]+-\d+",
+)
 def _main(compare_with: str | None, directory: str | None, config: str | None) -> None:
     """
     Check for new fragments on a branch.
@@ -65,7 +71,9 @@ def _main(compare_with: str | None, directory: str | None, config: str | None) -
 
 
 def __main(
-    comparewith: str | None, directory: str | None, config_path: str | None
+    comparewith: str | None,
+    directory: str | None,
+    config_path: str | None,
 ) -> None:
     base_directory, config = load_config_from_options(directory, config_path)
 
@@ -102,7 +110,11 @@ def __main(
     click.echo("----")
 
     # This will fail if any fragment files have an invalid name:
-    all_fragment_files = find_fragments(base_directory, config, strict=True)[1]
+    all_fragment_files = find_fragments(
+        base_directory,
+        config,
+        strict=True,
+    )[1]
 
     news_file = os.path.normpath(os.path.join(base_directory, config.filename))
     if news_file in files:

--- a/src/towncrier/test/test_check.py
+++ b/src/towncrier/test/test_check.py
@@ -514,3 +514,23 @@ class TestChecker(TestCase):
         result = runner.invoke(towncrier_check, ["--compare-with", "main"])
         self.assertEqual(1, result.exit_code, result.output)
         self.assertIn("Invalid news fragment name: feature.125", result.output)
+
+    # @with_isolated_runner
+    # def test_invalid_fragment_name_pattern(self, runner):
+    #     """
+    #     Fails if a news fragment has an invalid name, even if `ignore` is not set in
+    #     the config.
+    #     """
+    #     create_project(
+    #         "pyproject.toml",
+    #         extra_config=r'fragment_filename_stem_pattern = "[A-Z]+-\d+"',
+    #     )
+    #     write(
+    #         "foo/newsfragments/124.feature",
+    #         "This fragment has valid name (control case)",
+    #     )
+    #     commit("add stuff")
+
+    #     result = runner.invoke(towncrier_check, ["--compare-with", "main"])
+    #     self.assertEqual(1, result.exit_code, result.output)
+    #     self.assertIn("Invalid news fragment name: feature.125", result.output)


### PR DESCRIPTION
# Description

Fixes #<!-- add the associated GitHub Issue ID>

<!-- add a short summary if necessary; mention issue numbers -->


# Checklist
<!-- add a "X" inside the brackets to confirm -->
* [ ] Make sure changes are covered by existing or new tests.
* [ ] For at least one Python version, make sure test pass on your local environment.
* [ ] Create a file in `src/towncrier/newsfragments/`. Briefly describe your
  changes, with information useful to end users. Your change will be included in the public release notes.
* [ ] Make sure all GitHub Actions checks are green (they are automatically checking all of the above).
* [ ] Ensure `docs/tutorial.rst` is still up-to-date.
* [ ] If you add new **CLI arguments** (or change the meaning of existing ones), make sure `docs/cli.rst` reflects those changes.
* [ ] If you add new **configuration options** (or change the meaning of existing ones), make sure `docs/configuration.rst` reflects those changes.
